### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/clouduserp3bd4f9/1e68565f-a403-4a1e-a771-b2460006e345/3ad637af-9b82-4426-be5e-29d97ece1865/_apis/work/boardbadge/66ff216b-597b-452b-ae34-662e0b81e3e1)](https://dev.azure.com/clouduserp3bd4f9/1e68565f-a403-4a1e-a771-b2460006e345/_boards/board/t/3ad637af-9b82-4426-be5e-29d97ece1865/Microsoft.RequirementCategory)
 # ansible_essentials
 All lecture files from the Ansible Essentials course on Udemy.
 https://www.udemy.com/course/ansible-essentials/


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/clouduserp3bd4f9/1e68565f-a403-4a1e-a771-b2460006e345/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.